### PR TITLE
DNS, FS and setmeup features

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E231, E501, E722, W503, B950, B008
+ignore = E203, E231, E501, E722, W503, B950, B008, B905
 select = C,E,F,W,T,B,B9,I
 per-file-ignores =
     tests/*: T

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.9.3
+  rev: 5.11.5
   hooks:
   - id: isort
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,4 +116,5 @@ known_third_party = ["typer", "click"]
 [project.scripts]
 dice = "dice_cli.main:main"
 dicectl = "dice_cli.dicectl:main"
+dice-adm = "dice_cli.dicectl:main"
 # dicefs = "dice_cli.dicefs:main" # once `dice fs` is mature enough

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,4 @@ known_third_party = ["typer", "click"]
 [project.scripts]
 dice = "dice_cli.main:main"
 dicectl = "dice_cli.dicectl:main"
+# dicefs = "dice_cli.dicefs:main" # once `dice fs` is mature enough

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Development Status :: 1 - Planning",
@@ -86,7 +83,7 @@ all = true
 
 [tool.mypy]
 files = "src"
-python_version = "3.8"
+python_version = "3.9"
 warn_unused_configs = true
 
 disallow_any_generics = true

--- a/src/dice_cli/_date.py
+++ b/src/dice_cli/_date.py
@@ -37,7 +37,7 @@ def formatted_date(
     try:
         date_format = OPTION_TO_FORMAT[date_format_option]
     except KeyError:
-        msg = f"Invalid date format option '{date_format_option}'"
+        msg = f"Invalid date format option {date_format_option!r}"
         msg += f"\nValid options are: {', '.join(OPTION_TO_FORMAT.keys())}"
         raise ValueError(msg) from None
     return datetime.datetime.utcnow().strftime(date_format.value)

--- a/src/dice_cli/admin/deploy/_hdfs_mount.py
+++ b/src/dice_cli/admin/deploy/_hdfs_mount.py
@@ -80,7 +80,7 @@ def get_setup_commands() -> List[HostCommand]:
         HostCommand("ln", parameters=["-s", *link]) for link in config.symlinks
     ]
 
-    fstab_entry = f'"{config.fstab_entry}"'
+    fstab_entry = f"{config.fstab_entry!r}"
     make_mount_point = HostCommand("mkdir", parameters=["-p", config.mount_point])
     make_fstab_entry = HostCommand("echo", parameters=[fstab_entry, ">>", FSTAB_PATH])
     mount_hdfs = HostCommand("mount", parameters=[config.mount_point])

--- a/src/dice_cli/admin/report/__init__.py
+++ b/src/dice_cli/admin/report/__init__.py
@@ -150,3 +150,40 @@ def inventory(
             inventory_report, INVENTORY_COLUMNS, cast(Path, output_file)
         )
         admin_logger.info(f"Report saved to {output_file}")
+
+
+@app.command()
+def dns(
+    hosts: List[str] = typer.Argument(...),
+    output_file: Optional[Path] = typer.Option(
+        None,
+        "-o",
+        "--output",
+        help="Output file",
+    ),
+    print_to_console: bool = typer.Option(
+        False, "--print", help="Print to console instead of output file"
+    ),
+) -> None:
+    """
+    Generate a report of the DNS records for the given hosts.
+
+    :param hosts: The hosts to generate the report for.
+    :param output_directory: The directory to write the report to.
+    """
+    if not output_file and not print_to_console:
+        today = current_formatted_date()
+        output_file = Path(f"/tmp/{today}_dice_admin_dns_report.csv")
+
+    admin_logger.warning(":construction: Work in progress :construction:")
+    from ._dns import _dns_report
+
+    headers, dns_report = _dns_report(hosts)
+    if not print_to_console:
+        write_list_data_to_csv(dns_report, headers, cast(Path, output_file))
+        admin_logger.info(f"Report saved to {output_file}")
+    else:
+        admin_logger.info(
+            tabulate(dns_report, headers=headers, tablefmt="github"),
+            extra={"markup": False},
+        )

--- a/src/dice_cli/admin/report/_dns.py
+++ b/src/dice_cli/admin/report/_dns.py
@@ -1,0 +1,26 @@
+import socket
+from typing import List, Tuple
+
+from dice_cli.logger import admin_logger
+
+
+def _dns_report(hosts: List[str]) -> Tuple[List[str], List[Tuple[str, str, str]]]:
+    result = []
+    headers = [
+        "fqdn",
+        "ipv4",
+        "ipv6",
+    ]
+    for host in hosts:
+        fqdn = socket.getfqdn(host)
+        ipv4 = socket.gethostbyname(host)
+        try:
+            ipv6 = socket.getaddrinfo(host, None, socket.AF_INET6)[0][4][0]
+        except socket.gaierror:
+            admin_logger.warning("Unabled to find IPv6 address for %s", host)
+            ipv6 = "---"
+        host_info = (fqdn, ipv4, ipv6)
+        admin_logger.debug(f"{host} | {host_info}")
+        result.append(host_info)
+
+    return headers, result

--- a/src/dice_cli/benchmark/__init__.py
+++ b/src/dice_cli/benchmark/__init__.py
@@ -9,3 +9,22 @@ app = typer.Typer(help="Various benchmarks for DICE")
 def run_hepspec06() -> None:
     """Run the hepspec06 benchmark"""
     user_logger.warning("Not implemented yet")
+
+
+@app.command()
+def run_third_party_copy(src: str, dst: str, repeat: int = 10) -> None:
+    """Run the third party copy benchmark"""
+    user_logger.warning("Not implemented yet")
+    # check if cert proxy is available --> if not, create it via voms-proxy-init
+    # proxy is in /tmp/x509up_u`id -u`
+    # example copy command (enforce HTTPS for dst)
+    # gfal-copy -p -v -f -K adler32 --checksum-mode both --copy-mode pull src https://dst
+    for n in range(repeat):
+        user_logger.info(f"Copy {src} to {dst} ({n+1}/{repeat})")
+        # log if success or failure
+    # print summary table
+    # try to cleanup copied files on dst
+    for n in range(repeat):
+        user_logger.info(f"Cleanup {dst} ({n+1}/{repeat})")
+        # ignore failures
+        # gfal-rm davs://dst

--- a/src/dice_cli/fs/__init__.py
+++ b/src/dice_cli/fs/__init__.py
@@ -1,8 +1,23 @@
+from typing import Any
+
 import typer
+from dice_lib import load_config
 
 from ..logger import user_logger
 
 app = typer.Typer(help="DICE filesystem commands")
+
+
+def _prepare_paths(paths: list[str], config: dict[str, Any]) -> list[str]:
+    """
+    1. Remove trailing slashes from paths
+    2. lookup file system mounts
+    3. Replace protocols (e.g. /hdfs/<path> --> hdfs://<path>)
+    4. If no protocol is specified, assume local filesystem
+    """
+    if config:
+        pass
+    return [path.rstrip("/") for path in paths]
 
 
 @app.command()
@@ -20,5 +35,7 @@ def copy_from_local(
     dst : str
         Destination path.
     """
+    config = load_config()
+    src, dst = _prepare_paths([src, dst], config)
     user_logger.info(f"Copying file from local to DICE: {src} -> {dst}")
     user_logger.warning("Not implemented yet")

--- a/src/dice_cli/info/__init__.py
+++ b/src/dice_cli/info/__init__.py
@@ -1,10 +1,11 @@
 from typing import Dict, List
 
 import typer
-from dice_lib import parameters as dice_params
+from dice_lib import load_config
 
 from ..logger import user_logger
 
+dice_params = load_config()
 app = typer.Typer(help="DICE info commands")
 
 

--- a/src/dice_cli/main.py
+++ b/src/dice_cli/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, Optional
 
 import rich
@@ -94,6 +95,50 @@ def contribute() -> None:
     rich.print("[blue]  DICE CLI[/]: [red]https://github.com/uobdic/dice-cli[/]")
     rich.print("[blue]  DICE LIB[/]: [red]https://github.com/uobdic/dice-lib[/]")
     rich.print("[blue]  DICE WIKI[/]: [red]https://wikis.bris.ac.uk/display/dic[/]")
+
+
+def __create_dir(path: str) -> None:
+    """Create a directory if it does not exist"""
+    if os.path.exists(path):
+        user_logger.warning(f"Directory '{path}' already exists - skipping")
+        return
+    user_logger.info(f"Creating directory '{path}'")
+    try:
+        os.makedirs(path)
+    except Exception as e:
+        user_logger.error(f"Unable to create directory '{path}': {e}")
+        raise typer.Exit(1) from e
+
+
+@app.command()
+def setmeup() -> None:
+    """
+    Command to set you up across all DICE systems
+    """
+    from dice_lib.user import current_user
+
+    # create /storage/<username> directory
+    # create /scratch/<username> directory
+    # create /shared/<username> directory
+    # create /software/<username> directory
+    # check if hdfs://<username> exists --> if not, print instructions to create it
+    username = current_user()
+    local_paths = ["/storage", "/scratch", "/shared", "/software"]
+    dirs_to_create = [
+        os.path.join(path, username) for path in local_paths if os.path.exists(path)
+    ]
+    user_logger.info("Will create the following directories:")
+    for path in dirs_to_create:
+        user_logger.info(f"  {path}")
+    user_logger.info(
+        "For more information on the paths, please check the wiki for the current node you are on."
+    )
+
+    typer.confirm("Do you want to continue?", abort=True)
+
+    for path in local_paths:
+        if os.path.exists(path):
+            __create_dir(f"{path}/{username}")
 
 
 def main() -> Any:

--- a/src/dice_cli/main.py
+++ b/src/dice_cli/main.py
@@ -63,7 +63,7 @@ def glossary(
         return
 
     if word not in GLOSSARY:
-        rich.print(f"[red]Word '{word}' not found[/]")
+        rich.print(f"[red]Word {word!r} not found[/]")
         typer.echo("To list all glossary items use 'dice glossary -a'")
         return
 
@@ -100,13 +100,13 @@ def contribute() -> None:
 def __create_dir(path: str) -> None:
     """Create a directory if it does not exist"""
     if os.path.exists(path):
-        user_logger.warning(f"Directory '{path}' already exists - skipping")
+        user_logger.warning(f"Directory {path!r} already exists - skipping")
         return
-    user_logger.info(f"Creating directory '{path}'")
+    user_logger.info(f"Creating directory {path!r}")
     try:
         os.makedirs(path)
     except Exception as e:
-        user_logger.error(f"Unable to create directory '{path}': {e}")
+        user_logger.error(f"Unable to create directory {path!r}: {e}")
         raise typer.Exit(1) from e
 
 


### PR DESCRIPTION
- removes support for Python &lt; 3.9
- new feature: `report dns <hosts>` - shows DNS entries for given hosts
- new feature: new alias for `dicectl` (dice admin commands) - `dice-adm`
- placeholder: benchmark for Third Party Copy
- new feature: `dice setmeup` - creates folders for the most common mounts ("/storage", "/scratch", "/shared", "/software") - if present